### PR TITLE
fix: continue policy execution if namespaceObject cannot be fetched

### DIFF
--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -71,9 +71,8 @@ func Validate(payload []byte) ([]byte, error) {
 
 		responseBytes, err := kubernetes.GetResource(&host, resourceRequest)
 		if err != nil {
-			return nil, fmt.Errorf("cannot get namespace data: %w", err)
-		}
-		if err := json.Unmarshal(responseBytes, &namespaceObject); err != nil {
+			log.Printf("Warning: cannot get namespace data: %s. `namespaceObject` cannot be populated.", err)
+		} else if err := json.Unmarshal(responseBytes, &namespaceObject); err != nil {
 			return nil, fmt.Errorf("cannot parse namespace data: %w", err)
 		}
 	}


### PR DESCRIPTION
## Description
Continue the policy execution if `namespaceObject` cannot be fetched.
This can happen:
- if the policy is an `AdmissionPolicy`, which does not have context-aware capabilities by design
- if the user didn't configure a `ClusterAdmissionPolicy` with `v1/namespaces` context permissions. 

Fixes: #26 
