### PR TITLE
feat: Add `OCI.GetOCIManifest`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/cel-go v0.20.1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kubewarden/k8s-objects v1.29.0-kw1
-	github.com/kubewarden/policy-sdk-go v0.8.0
+	github.com/kubewarden/policy-sdk-go v0.8.1
 	github.com/stretchr/testify v1.8.4
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0

--- a/internal/cel/cel.go
+++ b/internal/cel/cel.go
@@ -64,6 +64,7 @@ func NewCompiler() (*Compiler, error) {
 		library.Crypto(),
 		library.Kubernetes(),
 		library.Net(),
+		library.OCI(),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/cel/cel.go
+++ b/internal/cel/cel.go
@@ -61,6 +61,7 @@ func NewCompiler() (*Compiler, error) {
 		cel.Variable("namespaceObject", cel.DynType),
 
 		// Kubewarden host capabilities libraries
+		library.Crypto(),
 		library.Kubernetes(),
 		library.Net(),
 	)


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/cel-policy/issues/31

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

Depends on https://github.com/kubewarden/policy-sdk-go/pull/82 and a new release of sdk-go v0.8.1.

Implements `OCI.GetOCIManifest` by returning the response as a CEL map.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
