### PR TITLE
feat: return response types instead of DynMap

### DIFF
--- a/internal/cel/library/crypto_test.go
+++ b/internal/cel/library/crypto_test.go
@@ -24,7 +24,7 @@ func TestCrypto(t *testing.T) {
 	}{
 		{
 			"verify",
-			"kw.crypto.certificate('cert.pem').certificateChain('chain1.pem').certificateChain('chain2.pem').notAfter(timestamp('2000-01-01T00:00:00Z')).verify()",
+			"kw.crypto.certificate('cert.pem').certificateChain('chain1.pem').certificateChain('chain2.pem').notAfter(timestamp('2000-01-01T00:00:00Z')).verify().isTrusted()",
 			"v1/is_certificate_trusted",
 			cryptoCap.CertificateVerificationRequest{
 				Cert: cryptoCap.Certificate{
@@ -47,10 +47,7 @@ func TestCrypto(t *testing.T) {
 				Trusted: true,
 				Reason:  "",
 			},
-			map[string]interface{}{
-				"isTrusted": true,
-				"reason":    "",
-			},
+			true,
 		},
 	}
 	for _, test := range tests {

--- a/internal/cel/library/sigstore_test.go
+++ b/internal/cel/library/sigstore_test.go
@@ -26,7 +26,7 @@ func TestSigstore(t *testing.T) {
 	}{
 		{
 			"pubKey verifier",
-			"kw.sigstore.image('image:latest').annotation('foo', 'bar').pubKey('key').pubKey('otherKey').verify().isTrusted",
+			"kw.sigstore.image('image:latest').annotation('foo', 'bar').pubKey('key').pubKey('otherKey').verify().isTrusted()",
 			"v2/verify",
 			verify.SigstorePubKeysVerify{
 				Image:       "image:latest",
@@ -41,7 +41,7 @@ func TestSigstore(t *testing.T) {
 		},
 		{
 			"kelyess verifier",
-			"kw.sigstore.image('image:latest').annotation('foo', 'bar').keyless('issuer', 'subject').keyless('otherIssuer', 'otherSubject').verify().digest",
+			"kw.sigstore.image('image:latest').annotation('foo', 'bar').keyless('issuer', 'subject').keyless('otherIssuer', 'otherSubject').verify().digest()",
 			"v2/verify",
 			verify.SigstoreKeylessVerifyExact{
 				Image:   "image:latest",
@@ -58,7 +58,7 @@ func TestSigstore(t *testing.T) {
 		},
 		{
 			"keylessPrefix verifier",
-			"kw.sigstore.image('image:latest').annotation('foo', 'bar').keylessPrefix('issuer', 'subject').keylessPrefix('otherIssuer', 'otherSubject').verify().isTrusted",
+			"kw.sigstore.image('image:latest').annotation('foo', 'bar').keylessPrefix('issuer', 'subject').keylessPrefix('otherIssuer', 'otherSubject').verify().isTrusted()",
 			"v2/verify",
 			verify.SigstoreKeylessPrefixVerify{
 				Image:         "image:latest",
@@ -75,7 +75,7 @@ func TestSigstore(t *testing.T) {
 		},
 		{
 			"github action verifier (owner and repo)",
-			"kw.sigstore.image('image:latest').annotation('foo', 'bar').githubAction('kubewarden', 'policy-server').verify().digest",
+			"kw.sigstore.image('image:latest').annotation('foo', 'bar').githubAction('kubewarden', 'policy-server').verify().digest()",
 			"v2/verify",
 			verify.SigstoreGithubActionsVerify{
 				Image: "image:latest",
@@ -93,7 +93,7 @@ func TestSigstore(t *testing.T) {
 		},
 		{
 			"github action verifier (owner)",
-			"kw.sigstore.image('image:latest').annotation('foo', 'bar').githubAction('kubewarden').verify().digest",
+			"kw.sigstore.image('image:latest').annotation('foo', 'bar').githubAction('kubewarden').verify().digest()",
 			"v2/verify",
 			verify.SigstoreGithubActionsVerify{
 				Image: "image:latest",
@@ -110,7 +110,7 @@ func TestSigstore(t *testing.T) {
 		},
 		{
 			"certificate verifier",
-			"kw.sigstore.image('image:latest').annotation('foo', 'bar').certificate('cert').certificateChain('chain1').certificateChain('chain2').requireRekorBundle(true).verify().isTrusted",
+			"kw.sigstore.image('image:latest').annotation('foo', 'bar').certificate('cert').certificateChain('chain1').certificateChain('chain2').requireRekorBundle(true).verify().isTrusted()",
 			"v2/verify",
 			verify.SigstoreCertificateVerify{
 				Image:       "image:latest",


### PR DESCRIPTION
## Description

Changes the crypto and the sigstore libraries to return a type (with getter methods) as a response instead of returning a dynamic map.

This is similar to what k8s is doing here: https://github.com/kubernetes/apiextensions-apiserver/blob/61b8b9cef04286f69fa14cc33a1faaafafc0dad5/pkg/apiserver/schema/cel/library/urls.go#L105 
due to: https://github.com/google/cel-go/issues/876

This change is needed to allow the CEL evaluation to know the type of expression when the above capabilities are used.
Since we validate that every `expression` evaluates to `bool`, using a dynamic map with this type of expression will result in an error:

`kw.crypto.(...).verify().isTrusted`

as the compiler does not know the type of the `isTrusted` key, being the map dynamic.

The expression needs now to be written as follows:

`kw.crypto(...).verify().isTrusted()` (note that `isTrusted` is now a method returning a bool)

