### PR TITLE
refactor(sigstore): rename github in githubAction

### DIFF
--- a/internal/cel/library/sigstore_test.go
+++ b/internal/cel/library/sigstore_test.go
@@ -74,8 +74,8 @@ func TestSigstore(t *testing.T) {
 			true,
 		},
 		{
-			"github verifier (owner and repo)",
-			"kw.sigstore.image('image:latest').annotation('foo', 'bar').github('kubewarden', 'policy-server').verify().digest",
+			"github action verifier (owner and repo)",
+			"kw.sigstore.image('image:latest').annotation('foo', 'bar').githubAction('kubewarden', 'policy-server').verify().digest",
 			"v2/verify",
 			verify.SigstoreGithubActionsVerify{
 				Image: "image:latest",
@@ -92,8 +92,8 @@ func TestSigstore(t *testing.T) {
 			"sha256:1234",
 		},
 		{
-			"github verifier (owner)",
-			"kw.sigstore.image('image:latest').annotation('foo', 'bar').github('kubewarden').verify().digest",
+			"github action verifier (owner)",
+			"kw.sigstore.image('image:latest').annotation('foo', 'bar').githubAction('kubewarden').verify().digest",
 			"v2/verify",
 			verify.SigstoreGithubActionsVerify{
 				Image: "image:latest",


### PR DESCRIPTION
## Description

Renames sigstore `github` verifier in `githubAction` verifier to be consistent with the policy server verification config: https://docs.kubewarden.io/howtos/secure-supply-chain#github-actions-signature-verification 
