### PR TITLE
feat: namespace object lazy loading

### DIFF
--- a/internal/validate/namespace_object.go
+++ b/internal/validate/namespace_object.go
@@ -1,0 +1,90 @@
+package validate
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/kubewarden/policy-sdk-go/pkg/capabilities"
+	"github.com/kubewarden/policy-sdk-go/pkg/capabilities/kubernetes"
+)
+
+var host = capabilities.NewHost()
+
+var (
+	namespaceObjectData map[string]interface{}
+	namespaceObjectType = types.NewObjectType("namespaceObject")
+)
+
+// namespaceObject provides an implementation of ref.Val for
+// any object type that has receiver functions but does not expose any fields to
+// CEL.
+type namespaceObject struct {
+	namespace string
+}
+
+// ConvertToNative implements ref.Val.ConvertToNative.
+func (a namespaceObject) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	return nil, fmt.Errorf("type conversion error from '%s' to '%v'", namespaceObjectType.String(), typeDesc)
+}
+
+// ConvertToType implements ref.Val.ConvertToType.
+func (a namespaceObject) ConvertToType(typeVal ref.Type) ref.Val {
+	switch typeVal {
+	case namespaceObjectType:
+		return a
+	case types.TypeType:
+		return namespaceObjectType
+	}
+	return types.NewErr("type conversion error from '%s' to '%s'", namespaceObjectType, typeVal)
+}
+
+// Equal implements ref.Val.Equal.
+func (a namespaceObject) Equal(_ ref.Val) ref.Val {
+	return types.NoSuchOverloadErr()
+}
+
+// Type implements ref.Val.Type.
+func (a namespaceObject) Type() ref.Type {
+	return namespaceObjectType
+}
+
+// Value implements ref.Val.Value.
+func (a namespaceObject) Value() any {
+	return namespaceObjectData
+}
+
+// Get returns the value fo a field name.
+func (a namespaceObject) Get(field ref.Val) ref.Val {
+	if namespaceObjectData == nil {
+		resourceRequest := kubernetes.GetResourceRequest{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+			Name:       a.namespace,
+		}
+
+		responseBytes, err := kubernetes.GetResource(&host, resourceRequest)
+		if err != nil {
+			return types.NewErr("cannot get namespace data: %s. `namespaceObject` cannot be populated.", err)
+		}
+
+		err = json.Unmarshal(responseBytes, &namespaceObjectData)
+		if err != nil {
+			return types.NewErr("cannot parse namespace data: %w", err)
+		}
+	}
+
+	fieldName, ok := field.Value().(string)
+	if !ok {
+		return types.ValOrErr(field, "no such field")
+	}
+
+	value, found := namespaceObjectData[fieldName]
+	if !found {
+		return types.ValOrErr(field, "no such field")
+	}
+
+	return types.DefaultTypeAdapter.NativeToValue(value)
+}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -33,7 +33,8 @@ func TestValidate(t *testing.T) {
 			},
 			object: &corev1.Pod{
 				Metadata: &metav1.ObjectMeta{
-					Name: "pod-name",
+					Name:      "pod-name",
+					Namespace: "default",
 				},
 			},
 			expectedValidationResponse: kubewardenProtocol.ValidationResponse{
@@ -166,6 +167,25 @@ func TestValidate(t *testing.T) {
 				Code:     code(400),
 			},
 		},
+		{
+			name: "namespaceObject lazy loading",
+			settings: settings.Settings{
+				Validations: []settings.Validation{
+					{
+						Expression: "namespaceObject.metadata.labels.foo == 'bar'",
+					},
+				},
+			},
+			object: &corev1.Pod{
+				Metadata: &metav1.ObjectMeta{
+					Name:      "pod-name",
+					Namespace: "default",
+				},
+			},
+			expectedValidationResponse: kubewardenProtocol.ValidationResponse{
+				Accepted: true,
+			},
+		},
 	}
 
 	// Override the host capabilities client with a mock client
@@ -179,6 +199,9 @@ func TestValidate(t *testing.T) {
 	response, err := json.Marshal(&corev1.Namespace{
 		Metadata: &metav1.ObjectMeta{
 			Name: "default",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
 		},
 	})
 	require.NoError(t, err)

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -26,7 +26,7 @@ func TestValidate(t *testing.T) {
 			settings: settings.Settings{
 				Validations: []settings.Validation{
 					{
-						Expression: `object.metadata.name != "pod-name"`,
+						Expression: "object.metadata.name != 'pod-name'",
 						Message:    "not true",
 					},
 				},
@@ -48,8 +48,8 @@ func TestValidate(t *testing.T) {
 			settings: settings.Settings{
 				Validations: []settings.Validation{
 					{
-						Expression:        `object.metadata.name != "namespace-name"`,
-						MessageExpression: `object.metadata.name + " is not allowed"`,
+						Expression:        "object.metadata.name != 'namespace-name'",
+						MessageExpression: "object.metadata.name + ' is not allowed'",
 					},
 				},
 			},
@@ -69,7 +69,7 @@ func TestValidate(t *testing.T) {
 			settings: settings.Settings{
 				Validations: []settings.Validation{
 					{
-						Expression: `object.metadata.name != "pod-name"`,
+						Expression: "object.metadata.name != 'pod-name'",
 					},
 				},
 			},
@@ -81,7 +81,7 @@ func TestValidate(t *testing.T) {
 			},
 			expectedValidationResponse: kubewardenProtocol.ValidationResponse{
 				Accepted: false,
-				Message:  message(`failed expression: object.metadata.name != "pod-name"`),
+				Message:  message("failed expression: object.metadata.name != 'pod-name'"),
 				Code:     code(400),
 			},
 		},
@@ -90,7 +90,7 @@ func TestValidate(t *testing.T) {
 			settings: settings.Settings{
 				Validations: []settings.Validation{
 					{
-						Expression: `object.metadata.name != "pod-name"`,
+						Expression: "object.metadata.name != 'pod-name'",
 						Reason:     settings.StatusReasonUnauthorized,
 						Message:    "failed",
 					},
@@ -113,7 +113,7 @@ func TestValidate(t *testing.T) {
 			settings: settings.Settings{
 				Validations: []settings.Validation{
 					{
-						Expression: `object.metadata.name != "pod-name"`,
+						Expression: "object.metadata.name != 'pod-name'",
 						Message:    "failed",
 						Reason:     settings.StatusReasonUnauthorized,
 					},
@@ -137,7 +137,7 @@ func TestValidate(t *testing.T) {
 				Variables: []settings.Variable{
 					{
 						Name:       "forbiddenName",
-						Expression: `"pod-name"`,
+						Expression: "'pod-name'",
 					},
 					{
 						Name:       "podMeta",
@@ -151,7 +151,7 @@ func TestValidate(t *testing.T) {
 				Validations: []settings.Validation{
 					{
 						Expression:        "variables.podName != variables.forbiddenName",
-						MessageExpression: `variables.forbiddenName + " is forbidden"`,
+						MessageExpression: "variables.forbiddenName + ' is forbidden'",
 					},
 				},
 			},


### PR DESCRIPTION
## Description

Kubernetes' `ValidatingAdmissionPolicy` expressions have access to the `namespaceObject` variable containing the namespace that the incoming object belongs to or null if the incoming object is cluster-scoped.

ATM we are fetching the namespace by using a context-aware call in the validate function.
The policy must have permission to get namespaces (by context-aware rules).
If the policy doesn't have the required permission or is of type `AdmissionPolicy`, we ignore the error and continue the evaluation.
However, this causes a lot of ambiguous errors in the policy server.

This PR introduces a `namespaceObject` type that fetches the object data through a context-aware call in a call-by-need strategy when a field is accessed (e.g. `namespaceObject.metadata.name`).

