### PR TITLE
refactor: simplify namespaceObject lazy-loading

### DIFF
--- a/internal/validate/namespace_object.go
+++ b/internal/validate/namespace_object.go
@@ -2,8 +2,6 @@ package validate
 
 import (
 	"encoding/json"
-	"fmt"
-	"reflect"
 
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -11,58 +9,17 @@ import (
 	"github.com/kubewarden/policy-sdk-go/pkg/capabilities/kubernetes"
 )
 
-var host = capabilities.NewHost()
-
 var (
+	host                = capabilities.NewHost()
 	namespaceObjectData map[string]interface{}
-	namespaceObjectType = types.NewObjectType("namespaceObject")
 )
 
-// namespaceObject provides an implementation of ref.Val for
-// any object type that has receiver functions but does not expose any fields to
-// CEL.
-type namespaceObject struct {
-	namespace string
-}
-
-// ConvertToNative implements ref.Val.ConvertToNative.
-func (a namespaceObject) ConvertToNative(typeDesc reflect.Type) (any, error) {
-	return nil, fmt.Errorf("type conversion error from '%s' to '%v'", namespaceObjectType.String(), typeDesc)
-}
-
-// ConvertToType implements ref.Val.ConvertToType.
-func (a namespaceObject) ConvertToType(typeVal ref.Type) ref.Val {
-	switch typeVal {
-	case namespaceObjectType:
-		return a
-	case types.TypeType:
-		return namespaceObjectType
-	}
-	return types.NewErr("type conversion error from '%s' to '%s'", namespaceObjectType, typeVal)
-}
-
-// Equal implements ref.Val.Equal.
-func (a namespaceObject) Equal(_ ref.Val) ref.Val {
-	return types.NoSuchOverloadErr()
-}
-
-// Type implements ref.Val.Type.
-func (a namespaceObject) Type() ref.Type {
-	return namespaceObjectType
-}
-
-// Value implements ref.Val.Value.
-func (a namespaceObject) Value() any {
-	return namespaceObjectData
-}
-
-// Get returns the value fo a field name.
-func (a namespaceObject) Get(field ref.Val) ref.Val {
+func getNamespaceObject(name string) ref.Val {
 	if namespaceObjectData == nil {
 		resourceRequest := kubernetes.GetResourceRequest{
 			APIVersion: "v1",
 			Kind:       "Namespace",
-			Name:       a.namespace,
+			Name:       name,
 		}
 
 		responseBytes, err := kubernetes.GetResource(&host, resourceRequest)
@@ -76,15 +33,5 @@ func (a namespaceObject) Get(field ref.Val) ref.Val {
 		}
 	}
 
-	fieldName, ok := field.Value().(string)
-	if !ok {
-		return types.ValOrErr(field, "no such field")
-	}
-
-	value, found := namespaceObjectData[fieldName]
-	if !found {
-		return types.ValOrErr(field, "no such field")
-	}
-
-	return types.DefaultTypeAdapter.NativeToValue(value)
+	return types.NewDynamicMap(types.DefaultTypeAdapter, namespaceObjectData)
 }


### PR DESCRIPTION
## Description

Simplify the lazy-loading of `namespaceObject` removing the custom type in favour of a simple function, as done for the variables in #57 
