### PR TITLE
ci: Configure Renovatebot to ignore k8s.io/apiserver

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,8 @@
   ],
   "labels": [
     "dependencies"
+  ],
+  "ignoreDeps": [
+    "k8s.io/apiserver"
   ]
 }


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

k8s.io/apiserver is in `./third_party` and bumped manually for now.
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Will retrigger renovatebot after merging.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
