### PR TITLE
Script to update third_party directory.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           bats-version: 1.11.0
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.3
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.4
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.3.3
+        uses: kubewarden/github-actions/kwctl-installer@v3.3.4
       - run: make e2e-tests
 
   golangci:

--- a/.github/workflows/update-third-party-dir.yaml
+++ b/.github/workflows/update-third-party-dir.yaml
@@ -1,0 +1,32 @@
+name: Update third party directory
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * MON" # Trigger this workflow every Monday at 00:00
+
+jobs:
+  third-party-update:
+    name: Update third party directory
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@d0950ebbe80f4f80c3392b288d6a218fae872f69 # v2.66.0
+
+      - name: Fetch latest Kubernetes released version
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+        run: "updatecli apply --debug --config ./updatecli/update_api_server_files.yaml"
+
+      - name: Updates  third party directory files
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+        run: "updatecli apply --debug --config ./updatecli/update_third_party_files.yaml --values /tmp/updatecli/values.yaml --values ./updatecli/values.yaml"

--- a/updatecli/scripts/install-third-party.sh
+++ b/updatecli/scripts/install-third-party.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -eux
+
+: ${REPOSITORY_DIR?"Missing REPOSITORY_DIR environment variable. This is the base directory where the files to be copied are located"}
+: ${DESTINATION_DIR?"Missing DESTINATION_DIR environment variable. This is the directory where the files will be copied into"}
+: ${FILES?"Missing FILES environment variable. These are the files to be copied, separated by spaces. Example: FILES=\"file1 file2 file3\""}
+
+# Check if the repository directory exists
+if [ ! -d "$REPOSITORY_DIR" ]; then
+    echo "Error: Base directory $REPOSITORY_DIR does not exist."
+    exit 1
+fi
+
+# Check if the destination directory exists
+if [ ! -d "$DESTINATION_DIR" ]; then
+    echo "Error: Destination directory $DESTINNATION_DIR does not exist."
+    exit 1
+fi
+
+
+# Loop through each file in the list
+for file in $FILES; do
+    # Find the file in the base directory
+    file_path="$REPOSITORY_DIR/$file"
+    
+    if [ -n "$file_path" ]; then
+        # Use the install command to copy the file and create the necessary directories
+        install -m "644" -D "$file_path" "$DESTINATION_DIR/$file"
+        echo "Copied $file_path to $DESTINATION_DIR/$file"
+    else
+        echo "File '$file_path' not found in $REPOSITORY_DIR."
+	exit 1
+    fi
+done
+
+echo "Done!"

--- a/updatecli/update_api_server_files.yaml
+++ b/updatecli/update_api_server_files.yaml
@@ -1,0 +1,79 @@
+name: "Get latest apiserver and apimachinery released version"
+
+scms:
+  apiServerGit:
+    kind: "git"
+    spec:
+        url: "https://github.com/kubernetes/apiserver.git"
+        branch: "master"
+  apiMachineryGit:
+    kind: "git"
+    spec:
+        url: "https://github.com/kubernetes/apimachinery.git"
+        branch: "master"
+
+sources:
+  latestApiServerTag: 
+    name: Get Latest apiserver tag
+    kind: gittag
+    scmid: apiServerGit
+    spec:
+      versionfilter:
+        kind: semver
+        pattern: <1
+    transformers:
+      - findsubmatch:
+          pattern: 'v\d*.(\d*.\d*)'
+          captureindex: 1
+      - addprefix: "1."
+  latestApiServerBranch: 
+    name: Get Latest apiserver release branch
+    kind: gittag
+    scmid: apiServerGit
+    spec:
+      versionfilter:
+        kind: semver
+        pattern: <1
+    transformers:
+      - findsubmatch:
+          pattern: 'v\d*.(\d*).\d*'
+          captureindex: 1
+      - addprefix: "release-1."
+
+conditions:
+  latestApiServerTag:
+    name: Check that the latest kubernetes tag exist in API Server
+    kind: gittag
+    sourceid: latestApiServerTag
+    scmid: apiServerGit
+    transformers:
+      - addprefix: "kubernetes-"
+  latestApiServerBranch:
+    name: Check that the latest kubernetes branch exist in API Server
+    kind: gitbranch
+    sourceid: latestApiServerBranch
+    scmid: apiServerGit
+  latestApiMachineryTag:
+    name: Check that the latest kubernetes tag exist in API Machinery
+    kind: gittag
+    sourceid: latestApiServerTag
+    scmid: apiMachineryGit
+    transformers:
+      - addprefix: "kubernetes-"
+  latestApiMachineryBranch:
+    name: Check that the latest kubernetes branch exist in API Machinery
+    kind: gitbranch
+    sourceid: latestApiServerBranch
+    scmid: apiMachineryGit
+
+targets:
+  # Save the tag and branch found in a file to be used in another updatecli script
+  update-apiserver-version:
+    kind: file
+    disablesourceinput: true
+    spec:
+      forcecreate: true
+      file: "/tmp/updatecli/values.yaml"
+      content: |
+        apiServerVersion: {{ source "latestApiServerTag" }}
+        apiServerReleaseBranch:  {{ source "latestApiServerBranch" }}

--- a/updatecli/update_third_party_files.yaml
+++ b/updatecli/update_third_party_files.yaml
@@ -1,0 +1,121 @@
+name: "Update the third party directory with files from Kubernetes repositories"
+
+scms:
+  apiServerGit:
+    kind: "git"
+    spec:
+      url: "https://github.com/kubernetes/apiserver.git"
+      branch: "{{ .apiServerReleaseBranch }}"
+  apiMachineryGit:
+    kind: "git"
+    spec:
+      url: "https://github.com/kubernetes/apimachinery.git"
+      branch: "{{ .apiServerReleaseBranch }}"
+  default:
+      kind: github
+      spec:
+        hidecredit: true
+        user: "{{ .github.author }}"
+        email: "{{ .github.email }}"
+        owner: "{{ requiredEnv .github.owner }}"
+        repository: "cel-policy"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ requiredEnv .github.user }}"
+        branch: "main"
+
+sources:
+  apiServerVersion:
+    kind: yaml
+    spec:
+      file: "/tmp/updatecli/values.yaml"
+      key: "$.apiServerVersion"
+  apiServerVersionNoMajor:
+    kind: yaml
+    spec:
+      file: "/tmp/updatecli/values.yaml"
+      key: "$.apiServerVersion"
+    transformers:
+      - findsubmatch:
+          pattern: '\d*.(\d*.\d*)'
+          captureindex: 1
+      - addprefix: "0."
+
+conditions:
+  updateRepo:
+    name: "Checkout apiserver repository"
+    kind: file
+    scmid: apiServerGit
+    disablesourceinput: true
+    spec:
+      file: go.mod
+  updateApiMachineryRepo:
+    name: "Checkout apimachinery repository"
+    kind: file
+    scmid: apiMachineryGit
+    disablesourceinput: true
+    spec:
+      file: go.mod
+
+targets:
+  readmeUpdate:
+    name: "Update third party directory README file"
+    kind: "file"
+    disablesourceinput: true
+    scmid: "default"
+    spec:
+      file: "./third_party/README.md"
+      content: |
+        This folder contains third-party code from kubernetes:
+        
+        - [kubernetes/apiserver](https://github.com/kubernetes/apiserver).
+        - [kubernetes/apimachinery](https://github.com/kubernetes/apimachinery).
+        
+        The current version is based on kubernetes v{{ source "apiServerVersion" }} (apiserver/apimachinery v{{ source "apiServerVersionNoMajor" }}).
+        
+        All code in this folder is licensed under the Apache License 2.0, see [LICENSE](LICENSE).
+  apiServerUpdate: 
+    name: "Get latest apiserver files"
+    kind: shell
+    scmid: "default"
+    disablesourceinput: true
+    spec:
+      command: bash updatecli/scripts/install-third-party.sh
+      environments:
+        - name: "REPOSITORY_DIR"
+          value: "/tmp/updatecli/github_com_kubernetes_apiserver_git"
+        - name: "DESTINATION_DIR"
+          value: "third_party/k8s.io/apiserver/"
+        - name: "FILES"
+          value: "pkg/apis/cel/config.go pkg/cel/errors.go pkg/cel/limits.go pkg/cel/quantity.go pkg/cel/types.go pkg/cel/url.go pkg/cel/value.go pkg/cel/OWNERS pkg/cel/library/lists.go pkg/cel/library/regex.go pkg/cel/library/test.go pkg/cel/library/urls.go"
+  apiMachineryUpdate: 
+    name: "Get latest apimachinery files"
+    kind: shell
+    scmid: "default"
+    disablesourceinput: true
+    spec:
+      command: bash updatecli/scripts/install-third-party.sh
+      environments:
+        - name: "REPOSITORY_DIR"
+          value: "/tmp/updatecli/github_com_kubernetes_apimachinery_git"
+        - name: "DESTINATION_DIR"
+          value: "third_party/k8s.io/apimachinery/"
+        - name: "FILES"
+          value: "pkg/api/resource/amount.go pkg/api/resource/quantity.go pkg/api/resource/math.go pkg/api/resource/scale_int.go pkg/api/resource/suffix.go"
+
+actions:
+  createUpdatePR:
+    kind: "github/pullrequest"
+    title: "Update third_party directory with files from Kubernetes v{{ .apiServerVersion }}"
+    scmid: "default"
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: |
+        Automatic third_party directory update with the files from the Kubernetes v{{ .apiServerVersion }}.
+
+        REMEMBER IF YOU WANT TO MERGE IN A SINGLE COMMIT CHANGES AND VERSION BUMP, YOU MUST SQUASH THE COMMIT BEFORE MERGING THIS PR!
+      draft: false
+      maintainercanmodify: true
+      labels:
+        - "kind/chore"
+        - "area/dependencies"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,6 @@
+github:
+  owner: "UPDATECLI_GITHUB_OWNER"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  author: "Kubewarden bot"
+  email: "cncf-kubewarden-maintainers@lists.cncf.io"
+  user: "UPDATECLI_GITHUB_OWNER"


### PR DESCRIPTION
## Description

Adds a new updatecli script to update the third_party directory files with the latest releases of the apiserver and apimachinery.

Fix #72 


It's possible to see the [CI](https://github.com/jvanz/cel-policy/actions/runs/10690320391) job and the consequent [PR](https://github.com/jvanz/cel-policy/pull/11) generated using the initial version of this PR in my fork. 