### PR TITLE
fix: Signed-off-by trailer in commits from automation.

### DIFF
--- a/updatecli/update_third_party_files.yaml
+++ b/updatecli/update_third_party_files.yaml
@@ -22,6 +22,8 @@ scms:
         token: "{{ requiredEnv .github.token }}"
         username: "{{ requiredEnv .github.user }}"
         branch: "main"
+        commitmessage:
+          footers: "Signed-off-by: Kubewarden maintainers <cncf-kubewarden-maintainers@cncf-kubewarden-maintainers>"
 
 sources:
   apiServerVersion:


### PR DESCRIPTION
## Description

Updates the updatecli script to add the git trailer "Signed-off-by". This is required by the DCO bot and the CI will not run if the commits are not signed.

