### PR TITLE
fix: eval variables fixes

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/kubewarden/cel-policy/internal/cel"
 	kubewarden "github.com/kubewarden/policy-sdk-go"
-	kubewardenProtocol "github.com/kubewarden/policy-sdk-go/protocol"
 )
 
 const (
@@ -64,15 +63,6 @@ func (v *Validation) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
-}
-
-func NewSettingsFromValidationReq(validationReq *kubewardenProtocol.ValidationRequest) (Settings, error) {
-	settings := Settings{}
-
-	if err := json.Unmarshal(validationReq.Settings, &settings); err != nil {
-		return Settings{}, fmt.Errorf("cannot unmarshal settings %w", err)
-	}
-	return settings, nil
 }
 
 // ValidateSettings validates the settings of the policy

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -141,7 +141,7 @@ func TestValidate(t *testing.T) {
 					},
 					{
 						Name:       "podMeta",
-						Expression: "object.metadata",
+						Expression: "request.object.metadata",
 					},
 					{
 						Name:       "podName",


### PR DESCRIPTION
While fixing issue #96, I found that the request object was being passed as a Go struct to the CEL environment. This made its fields only accessible by uppercase names, which isn't what the validating admission policy expects.

Fixes #96 and the request object issue.