### PR TITLE
feat: enable encoders extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ The following host capabilities are available:
 | [crypto](https://docs.kubewarden.io/reference/spec/host-capabilities/crypto)                        | Host-side cryptographic functions             | [**Crypto**](https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library#Crypto)         |
 | [net](https://docs.kubewarden.io/reference/spec/host-capabilities/net)                              | Network operations                            | [**Net**](https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library#Net)               |
 
+## Extensions
+
+CEL policy has some extensions that add extra functionality to the language that are not defined in the language definition. The CEL policy has the following extensions enabled:
+
+| Extension       | Description                                  | Documentation                                                                 |
+| --------------- | -------------------------------------------- | ----------------------------------------------------------------------------- |
+| Base64 Encoders | Allows users to encode/decode base64 strings | [Encoder extension](https://pkg.go.dev/github.com/google/cel-go/ext#Encoders) |
+
 ## Known limitations
 
 At the moment the policy does not support the following Kubernetes extensions:

--- a/internal/cel/cel.go
+++ b/internal/cel/cel.go
@@ -43,6 +43,8 @@ func NewCompiler() (*Compiler, error) {
 		ext.Sets(),
 		//nolint:mnd // extract the number 2 to a constant will not make the code more readable
 		ext.Strings(ext.StringsVersion(2)),
+		// allow base64 encoding/decoding
+		ext.Encoders(),
 		k8sLibrary.URLs(),
 		k8sLibrary.Regex(),
 		k8sLibrary.Lists(),


### PR DESCRIPTION
## Description

Enable the Encoders extension in the CEL environment allowing user to encode and decode base64 strings.

Fix #126

## Test

It's possible to test the new extension with the following settings:

```json
{
  "variables": [],
  "validations": [
    {
      "expression": "string(base64.decode(base64.encode(b'hello'))) == 'hello'",
      "messageExpression": "string(base64.decode(base64.encode(b'hello'))) + ' == ' + 'hello'",
      "reason": "Unauthorized"
    }
  ]
}
```
