### PR TITLE
chore: bump policy version to v1.3.0

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -15,7 +15,7 @@ executionMode: wasi
 backgroundAudit: true
 annotations:
   io.kubewarden.policy.title: cel-policy
-  io.kubewarden.policy.version: 1.2.2
+  io.kubewarden.policy.version: 1.3.0
   io.artifacthub.displayName: CEL Policy
   io.artifacthub.resources: Any
   io.artifacthub.keywords: compliance, CEL, ValidatingAdmissionPolicy, Common Expression Language


### PR DESCRIPTION
## Description

Updates the metadata.yml bumping the policy version to v1.3.0 to release the policy.

